### PR TITLE
Add Vixen.app cask v0.1.0

### DIFF
--- a/Casks/vixen.rb
+++ b/Casks/vixen.rb
@@ -1,0 +1,13 @@
+cask "vixen" do
+  version "0.1.0"
+  sha256 "a63300e4dadf29f9e5a92538531f3e5473c008dfa210815aa0c632e7501612ea"
+
+  url "https://github.com/bearcove/vixen-mac-app/releases/download/v#{version}/Vixen-#{version}.dmg"
+  name "Vixen"
+  desc "A Rust build engine with correct caching"
+  homepage "https://vixen.rs"
+
+  depends_on macos: ">= :tahoe"
+
+  app "Vixen.app"
+end


### PR DESCRIPTION
## Summary
- Adds a Homebrew cask for [Vixen.app](https://vixen.rs) v0.1.0
- DMG distributed from [bearcove/vixen-mac-app](https://github.com/bearcove/vixen-mac-app/releases/tag/v0.1.0)
- Requires macOS Tahoe (26+)

## Install

```bash
brew tap bearcove/tap
brew install --cask bearcove/tap/vixen
```